### PR TITLE
add `/1` or `/2` information back into read name if missing

### DIFF
--- a/subtract/calc-coverage-diff-2.py
+++ b/subtract/calc-coverage-diff-2.py
@@ -56,6 +56,20 @@ def main():
 
         #print('XXX', chr, start, end)
 
+        # add /1 or /2 if read is paired and is read 1 or read 2
+        if read.is_paired:
+            if read.is_read1:
+                if '/1' not in read.qname:
+                    read.qname += '/1'
+            elif read.is_read2:
+                if '/2' not in read.qname:
+                    read.qname += '/2'
+            else:
+                raise ValueError(f"read {read.qname} is paired but not read 1 or read 2")
+        else:
+            if '/1' not in read.qname:
+                read.qname += '/1'
+
         # for each position in query read, get coverage
         sum_cov = []
         for pos in range(start, end + 1):

--- a/subtract/calc-coverage-diff-sam-bam.py
+++ b/subtract/calc-coverage-diff-sam-bam.py
@@ -43,6 +43,20 @@ def main():
         start = read.reference_start
         end = read.reference_end
 
+        # add /1 or /2 if read is paired and is read 1 or read 2
+        if read.is_paired:
+            if read.is_read1:
+                if '/1' not in read.qname:
+                    read.qname += '/1'
+            elif read.is_read2:
+                if '/2' not in read.qname:
+                    read.qname += '/2'
+            else:
+                raise ValueError(f"read {read.qname} is paired but not read 1 or read 2")
+        else:
+            if '/1' not in read.qname:
+                read.qname += '/1'
+
         # for each position in query read, get coverage
         sum_cov = []
         for i in range(start, end + 1):


### PR DESCRIPTION
cc @ctb:

This PR modifies `calc-coverage-diff-2.py`  to add `/1` and `/2` read name suffixes back into each read name when missing. Read pair information is stored in the bam `FLAG` field, which pysam interprets for us.

When running `calc-coverage-diff-2.py` previously, we were running into issues where we only had read pair information for some files. Upon digging, this may be because the `bam2fq` step used in `genome-grist` adds `/1` and `/2` information back into read names after it is presumably dropped in the minimap2 step. 


